### PR TITLE
Remove unnecesary template declaration of communicator::iprobe

### DIFF
--- a/mpl/comm_group.hpp
+++ b/mpl/comm_group.hpp
@@ -892,7 +892,7 @@ namespace mpl {
     }
 
     // --- nonblocking probe ---
-    template<typename T>
+    //template<typename T>
     std::pair<bool, status> iprobe(int source, tag t=tag(0)) const {
       check_source(source);
       check_recv_tag(t);

--- a/mpl/comm_group.hpp
+++ b/mpl/comm_group.hpp
@@ -891,8 +891,7 @@ namespace mpl {
       return s;
     }
 
-    // --- nonblocking probe ---
-    //template<typename T>
+    // --- nonblocking probe ---    
     std::pair<bool, status> iprobe(int source, tag t=tag(0)) const {
       check_source(source);
       check_recv_tag(t);


### PR DESCRIPTION
Fixes #2 