### PR TITLE
Remove unused variable from graph_communicator constructor

### DIFF
--- a/mpl/graph_comm.hpp
+++ b/mpl/graph_comm.hpp
@@ -55,12 +55,10 @@ namespace mpl {
       for (const auto &e : es)
         nodes=std::max({ nodes, e.first+1, e.second+1 });
       int node=0;
-      int degree=0;
       std::vector<int> edges, index(nodes, 0);
       for (const auto &e : es) {
         while (e.first>node) {
           ++node;
-          degree=0;
         }
         edges.push_back(e.second);
         index[e.first]+=1;


### PR DESCRIPTION
The compiler was complaining every time about this.