### PR TITLE
Provide a method to attach an existing communicator to `mpl::communicator`

### DIFF
--- a/mpl/comm_group.hpp
+++ b/mpl/comm_group.hpp
@@ -277,6 +277,8 @@ namespace mpl {
 
     class base_communicator {
     protected:
+      bool attached = false;
+
       struct isend_irecv_request_state {
         MPI_Datatype datatype{MPI_DATATYPE_NULL};
         int count{MPI_UNDEFINED};
@@ -434,7 +436,7 @@ namespace mpl {
       }
 
       ~base_communicator() {
-        if (is_valid()) {
+        if (!attached && is_valid()) {
           int result_1;
           MPI_Comm_compare(comm_, MPI_COMM_WORLD, &result_1);
           int result_2;
@@ -4135,6 +4137,15 @@ namespace mpl {
       if (this != &other)
         base::operator=(static_cast<base &&>(other));
       return *this;
+    }
+
+    void attach(MPI_Comm comm_c) {
+      attached = true;
+      comm_ = comm_c;
+    }
+
+    void attach(int comm_f) {
+      attach(MPI_Comm_f2c(comm_f));
     }
 
     /// Determines the total number of processes in a communicator.

--- a/mpl/comm_group.hpp
+++ b/mpl/comm_group.hpp
@@ -277,8 +277,6 @@ namespace mpl {
 
     class base_communicator {
     protected:
-      bool attached = false;
-
       struct isend_irecv_request_state {
         MPI_Datatype datatype{MPI_DATATYPE_NULL};
         int count{MPI_UNDEFINED};
@@ -400,6 +398,7 @@ namespace mpl {
       }
 
       MPI_Comm comm_{MPI_COMM_NULL};
+      bool attached_ = false;
 
     public:
       /// Indicates the creation of a new communicator by an operation that is collective
@@ -451,14 +450,15 @@ namespace mpl {
         if (this != &other) {
           destroy();
           comm_ = other.comm_;
+          attached_ = other.attached_;
           other.comm_ = MPI_COMM_NULL;
-          attached = other.attached;
+          other.attached_ = false;  // not necessary, but for clarity
         }
         return *this;
       }
 
       void destroy() {
-        if (!attached && is_valid()) {
+        if (!attached_ && is_valid()) {
           int result_1;
           MPI_Comm_compare(comm_, MPI_COMM_WORLD, &result_1);
           int result_2;
@@ -466,7 +466,7 @@ namespace mpl {
           if (result_1 != MPI_IDENT and result_2 != MPI_IDENT)
             MPI_Comm_free(&comm_);
         }
-        attached = false;
+        attached_ = false;
       }
 
       [[nodiscard]] int size() const {
@@ -4133,7 +4133,7 @@ namespace mpl {
 
     void attach(MPI_Comm comm_c) {
       destroy();
-      attached = true;
+      attached_ = true;
       comm_ = comm_c;
     }
 

--- a/mpl/comm_group.hpp
+++ b/mpl/comm_group.hpp
@@ -452,6 +452,7 @@ namespace mpl {
           destroy();
           comm_ = other.comm_;
           other.comm_ = MPI_COMM_NULL;
+          attached = other.attached;
         }
         return *this;
       }

--- a/mpl/comm_group.hpp
+++ b/mpl/comm_group.hpp
@@ -4137,6 +4137,7 @@ namespace mpl {
       comm_ = comm_c;
     }
 
+    template<typename T = MPI_Comm, std::enable_if_t<!std::is_same_v<T, int>, int> = 0>
     void attach(int comm_f) {
       attach(MPI_Comm_f2c(comm_f));
     }

--- a/test/test_communicator.cc
+++ b/test/test_communicator.cc
@@ -42,6 +42,21 @@ bool communicator_comm_world_copy_test() {
 }
 
 
+// test properties of a newly created communicator via attaching an existing MPI_Comm
+bool communicator_comm_world_copy_test() {
+  const mpl::communicator &comm_world{mpl::environment::comm_world()};
+  mpl::communicator comm_new;
+  comm_new.attach(MPI_COMM_WORLD);
+  if (not comm_new.is_valid())
+    return false;
+  if (comm_world.size() != comm_new.size())
+    return false;
+  if (comm_new.compare(comm_world) != mpl::communicator::congruent)
+    return false;
+  return true;
+}
+
+
 // test properties of a newly created communicator
 bool communicator_comm_world_split_test() {
   const mpl::communicator &comm_world{mpl::environment::comm_world()};


### PR DESCRIPTION
See #41 
