### PR TITLE
Fix MPI initialization and finalization checks in initializer

### DIFF
--- a/mpl/comm_group.hpp
+++ b/mpl/comm_group.hpp
@@ -277,6 +277,8 @@ namespace mpl {
 
     class base_communicator {
     protected:
+      bool attached = false;
+
       struct isend_irecv_request_state {
         MPI_Datatype datatype{MPI_DATATYPE_NULL};
         int count{MPI_UNDEFINED};
@@ -434,7 +436,7 @@ namespace mpl {
       }
 
       ~base_communicator() {
-        if (is_valid()) {
+        if (!attached && is_valid()) {
           int result_1;
           MPI_Comm_compare(comm_, MPI_COMM_WORLD, &result_1);
           int result_2;
@@ -4135,6 +4137,15 @@ namespace mpl {
       if (this != &other)
         base::operator=(static_cast<base &&>(other));
       return *this;
+    }
+
+    void attach(MPI_Comm comm_c) {
+      attached = true;
+      comm_ = comm_c;
+    }
+
+    void attach(int comm_f) {
+      attach(MPI_Comm_f2c(comm_f));
     }
 
     /// Determines the total number of processes in a communicator.

--- a/mpl/comm_group.hpp
+++ b/mpl/comm_group.hpp
@@ -277,8 +277,6 @@ namespace mpl {
 
     class base_communicator {
     protected:
-      bool attached = false;
-
       struct isend_irecv_request_state {
         MPI_Datatype datatype{MPI_DATATYPE_NULL};
         int count{MPI_UNDEFINED};
@@ -400,6 +398,7 @@ namespace mpl {
       }
 
       MPI_Comm comm_{MPI_COMM_NULL};
+      bool attached_ = false;
 
     public:
       /// Indicates the creation of a new communicator by an operation that is collective
@@ -451,14 +450,15 @@ namespace mpl {
         if (this != &other) {
           destroy();
           comm_ = other.comm_;
+          attached_ = other.attached_;
           other.comm_ = MPI_COMM_NULL;
-          attached = other.attached;
+          other.attached_ = false;  // not necessary, but for clarity
         }
         return *this;
       }
 
       void destroy() {
-        if (!attached && is_valid()) {
+        if (!attached_ && is_valid()) {
           int result_1;
           MPI_Comm_compare(comm_, MPI_COMM_WORLD, &result_1);
           int result_2;
@@ -466,7 +466,7 @@ namespace mpl {
           if (result_1 != MPI_IDENT and result_2 != MPI_IDENT)
             MPI_Comm_free(&comm_);
         }
-        attached = false;
+        attached_ = false;
       }
 
       [[nodiscard]] int size() const {
@@ -4133,7 +4133,7 @@ namespace mpl {
 
     void attach(MPI_Comm comm_c) {
       destroy();
-      attached = true;
+      attached_ = true;
       comm_ = comm_c;
     }
 

--- a/mpl/comm_group.hpp
+++ b/mpl/comm_group.hpp
@@ -452,6 +452,7 @@ namespace mpl {
           destroy();
           comm_ = other.comm_;
           other.comm_ = MPI_COMM_NULL;
+          attached = other.attached;
         }
         return *this;
       }

--- a/mpl/comm_group.hpp
+++ b/mpl/comm_group.hpp
@@ -5139,8 +5139,10 @@ namespace mpl {
       // performing some deep copies in order to avoid const_cast
       std::vector<std::vector<char>> args;
       args.reserve(command.size() - 1);
-      for (command_line::size_type i{1}; i < command.size(); ++i)
+      for (command_line::size_type i{1}; i < command.size(); ++i) {
         args.push_back(std::vector<char>(command[i].begin(), command[i].end()));
+        args.back().push_back('\0');  // std::string is not null-terminated
+      }
       std::vector<char *> args_pointers;
       args_pointers.reserve(args.size() + 1);
       for (auto &arg : args)

--- a/mpl/comm_group.hpp
+++ b/mpl/comm_group.hpp
@@ -4137,6 +4137,7 @@ namespace mpl {
       comm_ = comm_c;
     }
 
+    template<typename T = MPI_Comm, std::enable_if_t<!std::is_same_v<T, int>, int> = 0>
     void attach(int comm_f) {
       attach(MPI_Comm_f2c(comm_f));
     }

--- a/mpl/datatype.hpp
+++ b/mpl/datatype.hpp
@@ -307,7 +307,7 @@ namespace mpl {
 
   public:
     struct_builder() {
-      T array[N0];
+      T array[N0]{};
       layout_.register_struct(array);
       layout_.register_element(array);
       base::define_struct(layout_);

--- a/mpl/environment.hpp
+++ b/mpl/environment.hpp
@@ -35,7 +35,12 @@ namespace mpl {
 
         public:
           initializer() {
-            MPI_Init_thread(nullptr, nullptr, MPI_THREAD_MULTIPLE, &thread_mode_);
+            int is_initialized;
+            MPI_Initialized(&is_initialized);
+            if (!is_initialized)
+              MPI_Init_thread(nullptr, nullptr, MPI_THREAD_MULTIPLE, &thread_mode_);
+            else
+              MPI_Query_thread(&thread_mode_);
           }
 
           ~initializer() {

--- a/mpl/environment.hpp
+++ b/mpl/environment.hpp
@@ -38,7 +38,12 @@ namespace mpl {
             MPI_Init_thread(nullptr, nullptr, MPI_THREAD_MULTIPLE, &thread_mode_);
           }
 
-          ~initializer() { MPI_Finalize(); }
+          ~initializer() {
+            int is_finalized;
+            MPI_Finalized(&is_finalized);
+            if (!is_finalized)
+              MPI_Finalize();
+          }
 
           [[nodiscard]] threading_modes thread_mode() const {
             switch (thread_mode_) {

--- a/mpl/file.hpp
+++ b/mpl/file.hpp
@@ -147,8 +147,13 @@ namespace mpl {
     void open(const communicator &comm, const std::filesystem::path &name, access_mode mode,
               const info &i = info{}) {
       using int_type = std::underlying_type_t<file::access_mode>;
-      const int err{MPI_File_open(comm.comm_, name.c_str(), static_cast<int_type>(mode),
-                                  i.info_, &file_)};
+      const int err{MPI_File_open(comm.comm_,
+#ifdef _WIN32
+                                  name.string().c_str(),
+#else
+                                  name.c_str(),
+#endif
+                                  static_cast<int_type>(mode), i.info_, &file_)};
       if (err != MPI_SUCCESS)
         throw io_failure(err);
     }

--- a/mpl/layout.hpp
+++ b/mpl/layout.hpp
@@ -1787,6 +1787,7 @@ namespace mpl {
     using base::operator[];
     using base::size;
     using base::push_back;
+    using base::clear;
 
     friend class impl::base_communicator;
     friend class impl::topology_communicator;

--- a/mpl/utility.hpp
+++ b/mpl/utility.hpp
@@ -7,6 +7,7 @@
 #include <type_traits>
 #include <vector>
 #include <valarray>
+#include <string>
 
 namespace mpl::detail {
 

--- a/test/test_communicator.cc
+++ b/test/test_communicator.cc
@@ -42,6 +42,21 @@ bool communicator_comm_world_copy_test() {
 }
 
 
+// test properties of a newly created communicator via attaching an existing MPI_Comm
+bool communicator_comm_world_copy_test() {
+  const mpl::communicator &comm_world{mpl::environment::comm_world()};
+  mpl::communicator comm_new;
+  comm_new.attach(MPI_COMM_WORLD);
+  if (not comm_new.is_valid())
+    return false;
+  if (comm_world.size() != comm_new.size())
+    return false;
+  if (comm_new.compare(comm_world) != mpl::communicator::congruent)
+    return false;
+  return true;
+}
+
+
 // test properties of a newly created communicator
 bool communicator_comm_world_split_test() {
   const mpl::communicator &comm_world{mpl::environment::comm_world()};


### PR DESCRIPTION
Ensure the initializer checks if MPI is already initialized before calling `MPI_Init_thread` and verifies if MPI is finalized before calling `MPI_Finalize`.

This allows mpl to be used with other libraries that also manages MPI environment, one can then better manage MPI, avoiding double initialisation/finalisation error.