### PR TITLE
Fix MPI initialization and finalization checks in initializer

### DIFF
--- a/mpl/environment.hpp
+++ b/mpl/environment.hpp
@@ -35,7 +35,12 @@ namespace mpl {
 
         public:
           initializer() {
-            MPI_Init_thread(nullptr, nullptr, MPI_THREAD_MULTIPLE, &thread_mode_);
+            int is_initialized;
+            MPI_Initialized(&is_initialized);
+            if (!is_initialized)
+              MPI_Init_thread(nullptr, nullptr, MPI_THREAD_MULTIPLE, &thread_mode_);
+            else
+              MPI_Query_thread(&thread_mode_);
           }
 
           ~initializer() {

--- a/mpl/environment.hpp
+++ b/mpl/environment.hpp
@@ -38,7 +38,12 @@ namespace mpl {
             MPI_Init_thread(nullptr, nullptr, MPI_THREAD_MULTIPLE, &thread_mode_);
           }
 
-          ~initializer() { MPI_Finalize(); }
+          ~initializer() {
+            int is_finalized;
+            MPI_Finalized(&is_finalized);
+            if (!is_finalized)
+              MPI_Finalize();
+          }
 
           [[nodiscard]] threading_modes thread_mode() const {
             switch (thread_mode_) {


### PR DESCRIPTION
Ensure the initializer checks if MPI is already initialized before calling `MPI_Init_thread` and verifies if MPI is finalized before calling `MPI_Finalize`.

This allows mpl to be used with other libraries that also manages MPI environment, one can then better manage MPI, avoiding double initialisation/finalisation error.
