### PR TITLE
Update CMakeLists.txt to better support MPL as a subproject

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,9 @@ cmake_minimum_required(VERSION 3.10)
 # but semantic versioning should be considered
 project(mpl VERSION 0.4.0 LANGUAGES CXX C)
 
+# https://cmake.org/cmake/help/latest/variable/PROJECT_IS_TOP_LEVEL.html
+string(COMPARE EQUAL ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_SOURCE_DIR} PROJECT_IS_TOP_LEVEL)
+
 if(NOT DEFINED CACHE{BUILD_TESTING})
   set(BUILD_TESTING OFF CACHE BOOL "")
 endif()
@@ -19,8 +22,7 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
-find_package(MPI REQUIRED)
-find_package(Threads REQUIRED)
+find_package(MPI 3.1 REQUIRED C)
 
 add_library(mpl INTERFACE)
 target_include_directories(mpl
@@ -30,9 +32,9 @@ target_include_directories(mpl
 
 # convention for allowing use as a subdirectory
 add_library(mpl::mpl ALIAS mpl)
-target_link_libraries(mpl INTERFACE Threads::Threads MPI::MPI_CXX)
+target_link_libraries(mpl INTERFACE MPI::MPI_C)
 
-option(MPL_BUILD_EXAMPLES "build the mpl examples" OFF)
+option(MPL_BUILD_EXAMPLES "build the mpl examples" ${PROJECT_IS_TOP_LEVEL})
 if(MPL_BUILD_EXAMPLES)
   add_subdirectory(examples)
 endif()
@@ -40,18 +42,21 @@ if(BUILD_TESTING)
   add_subdirectory(test)
 endif()
 
-install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/cmake/mplConfig.cmake DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/mpl)
+option(MPL_INSTALL "Generate and install MPL target" ${PROJECT_IS_TOP_LEVEL})
+if(MPL_INSTALL)
+  install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/cmake/mplConfig.cmake DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/mpl)
 
-install(DIRECTORY mpl DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+  install(DIRECTORY mpl DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
-install(TARGETS mpl EXPORT mplTargets)
-export(EXPORT mplTargets
-    NAMESPACE mpl::
-    FILE mplTargets.cmake)
-install(EXPORT mplTargets
-    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/mpl
-    NAMESPACE mpl::
-    FILE mplTargets.cmake)
+  install(TARGETS mpl EXPORT mplTargets)
+  export(EXPORT mplTargets
+      NAMESPACE mpl::
+      FILE mplTargets.cmake)
+  install(EXPORT mplTargets
+      DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/mpl
+      NAMESPACE mpl::
+      FILE mplTargets.cmake)
+endif()
 
 option(MPL_BUILD_DOCUMENTATION "build the mpl documentation using Doxygen and Sphinx" OFF)
 add_subdirectory(doc)


### PR DESCRIPTION
Updates:
- Add variable `PROJECT_IS_TOP_LEVEL` to determine whether it is a subproject (`false` if it is).
- Add option `MPL_INSTALL` to control whether MPL will be installed. A subproject is not necessarily have to be installed. The default value is set to be `${PROJECT_IS_TOP_LEVEL}` so it won't break independent build.
- Set `MPL_BUILD_EXAMPLES`'s default value to `${PROJECT_IS_TOP_LEVEL}`.
- Link to `MPI_C` instead of `MPI_CXX`, since `MPI_CXX` refers to the deprecated MPI official API, and I believe that they are not used in MPL. Also set the minimum version of MPI to 3.1 for consistency.
- Remove the `find_package` to `Threads::Threads` since we are using C++17 and not explicitly using pthread.