### PR TITLE
Fix GCC -Wmaybe-uninitialized

### DIFF
--- a/mpl/comm_group.hpp
+++ b/mpl/comm_group.hpp
@@ -2999,7 +2999,6 @@ namespace mpl {
         check_size(recvdispls);
         const auto recvcounts{sizes_as_vector_of_ints(recvls)};
         const auto recvdispls_int(count_displacements_as_vector_of_ints<T>(recvdispls));
-        const std::vector<int> displs(recvdispls.begin(), recvdispls.end());
         MPI_Allgatherv(send_data, sendl.size(), detail::datatype_traits<T>::get_datatype(),
                        recv_data, recvcounts.data(), recvdispls_int.data(),
                        detail::datatype_traits<T>::get_datatype(), comm_);
@@ -3294,7 +3293,6 @@ namespace mpl {
         check_size(senddispls);
         const auto sendcounts{sizes_as_vector_of_ints(sendls)};
         const auto senddispls_int(count_displacements_as_vector_of_ints<T>(senddispls));
-        const std::vector<int> displs(senddispls.begin(), senddispls.end());
         MPI_Scatterv(send_data, sendcounts.data(), senddispls_int.data(),
                      detail::datatype_traits<T>::get_datatype(), recv_data, recvl.size(),
                      detail::datatype_traits<T>::get_datatype(), root_rank, comm_);

--- a/mpl/datatype.hpp
+++ b/mpl/datatype.hpp
@@ -398,7 +398,7 @@ namespace mpl {
 
   public:
     struct_builder() {
-      std::array<T, N> array;
+      std::array<T, N> array{};
       layout_.register_struct(array);
       layout_.register_element(array);
       base::define_struct(layout_);


### PR DESCRIPTION
I find that `allgather`ing `std::array<char, N>` (N>=229) will trigger a compile warning with GCC 14.2/13.3/12.4 (but ok for Clang). Here is an example:
```C++
#include <mpl/mpl.hpp>

int main() {
  constexpr std::size_t n{229}; // n >= 229 will trigger gcc 14.2 -Wmaybe-uninitialized

  const auto& commWorld{mpl::environment::comm_world()};
  std::array<char, n> a{};
  std::vector<std::array<char, n>> b(commWorld.size());
  commWorld.allgather(a, b.data());

  return EXIT_SUCCESS;
}
```
And the warning looks like this:
```
In file included from /home/zhaoshihan/Documents/repos/mpl/mpl/mpl.hpp:51,
                 from /home/zhaoshihan/Documents/repos/mpl/examples/arrays.cc:4:
In member function ‘mpl::struct_layout<S>& mpl::struct_layout<S>::register_struct(const S&) [with S = std::array<char, 256>]’,
    inlined from ‘mpl::struct_builder<std::array<_Tp, _Nm> >::struct_builder() [with T = char; long unsigned int N = 256]’ at /home/zhaoshihan/Documents/repos/mpl/mpl/datatype.hpp:402:30:
/home/zhaoshihan/Documents/repos/mpl/mpl/datatype.hpp:135:22: warning: ‘array’ may be used uninitialized [-Wmaybe-uninitialized]
  135 |       MPI_Get_address(const_cast<S *>(&x), &base_);
      |       ~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /home/zhaoshihan/Documents/repos/mpl/mpl/mpl.hpp:5:
/usr/lib/x86_64-linux-gnu/openmpi/include/mpi.h: In constructor ‘mpl::struct_builder<std::array<_Tp, _Nm> >::struct_builder() [with T = char; long unsigned int N = 256]’:
/usr/lib/x86_64-linux-gnu/openmpi/include/mpi.h:1677:20: note: by argument 1 of type ‘const void*’ to ‘int MPI_Get_address(const void*, MPI_Aint*)’ declared here
 1677 | OMPI_DECLSPEC  int MPI_Get_address(const void *location, MPI_Aint *address);
      |                    ^~~~~~~~~~~~~~~
/home/zhaoshihan/Documents/repos/mpl/mpl/datatype.hpp:401:24: note: ‘array’ declared here
  401 |       std::array<T, N> array;
      |                        ^~~~~
```
The interesting thing is if N<229 the warning is gone.

Nevertheless, I believe we can simply add a value initialization to make GCC happy since this array is just a template here.